### PR TITLE
Add root API health check

### DIFF
--- a/server.js
+++ b/server.js
@@ -60,6 +60,13 @@ app.use('/api/ratings', ratingRouter);
 app.use('/api/fare', fareRouter);
 app.use('/api/notifications', notificationRouter);
 
+// Root health check route
+app.get('/', (req, res) => {
+  res.send(
+    '🚀 Grab SuperApp API is running. Available endpoints start with /api/'
+  );
+});
+
 // Global error handler
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary
- add a simple root route that returns a message

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68848b7b88ac832b970467ccbce5d4be