### PR TITLE
Add trending content support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# backend-rakshit-grab
+# Grab SuperApp Backend
+
+This repository contains the Express based backend for the Grab SuperApp. It handles services such as taxi rides, food and mart orders, porter and medicine delivery. A flat 10% commission plus 18% GST is applied on every order. The API also provides endpoints for trending content including movies, activities and local news.

--- a/server.js
+++ b/server.js
@@ -43,6 +43,9 @@ import adminRouter from './src/routes/adminRoutes.js';
 import ratingRouter from './src/routes/ratingRoutes.cjs';
 import fareRouter from './src/routes/fareRoutes.js';
 import notificationRouter from './src/routes/notificationRoutes.js';
+import movieRouter from './src/routes/movieRoutes.js';
+import activityRouter from './src/routes/activityRoutes.js';
+import newsRouter from './src/routes/newsRoutes.js';
 
 // Mount API routes
 app.use('/api/users', userRouter);
@@ -59,6 +62,9 @@ app.use('/api/admin', adminRouter);
 app.use('/api/ratings', ratingRouter);
 app.use('/api/fare', fareRouter);
 app.use('/api/notifications', notificationRouter);
+app.use('/api/movies', movieRouter);
+app.use('/api/activities', activityRouter);
+app.use('/api/news', newsRouter);
 
 // Root health check route
 app.get('/', (req, res) => {

--- a/src/models/activityModel.js
+++ b/src/models/activityModel.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const activitySchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    description: String,
+    date: Date,
+    location: String,
+    image: String,
+    link: String,
+    trending: { type: Boolean, default: false }
+  },
+  { timestamps: true }
+);
+
+const Activity = mongoose.model('Activity', activitySchema);
+export default Activity;

--- a/src/models/movieModel.js
+++ b/src/models/movieModel.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+const movieSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    description: String,
+    image: String,
+    link: String,
+    releaseDate: Date,
+    trending: { type: Boolean, default: false }
+  },
+  { timestamps: true }
+);
+
+const Movie = mongoose.model('Movie', movieSchema);
+export default Movie;

--- a/src/models/newsModel.js
+++ b/src/models/newsModel.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+const newsSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    content: String,
+    image: String,
+    link: String,
+    publishedAt: Date,
+    trending: { type: Boolean, default: false }
+  },
+  { timestamps: true }
+);
+
+const News = mongoose.model('News', newsSchema);
+export default News;

--- a/src/routes/activityRoutes.js
+++ b/src/routes/activityRoutes.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import Activity from '../models/activityModel.js';
+
+const router = express.Router();
+
+// Get all activities
+router.get('/', async (req, res) => {
+  const activities = await Activity.find().sort({ createdAt: -1 });
+  res.json(activities);
+});
+
+// Create an activity
+router.post('/', async (req, res) => {
+  try {
+    const activity = await Activity.create(req.body);
+    res.status(201).json(activity);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/src/routes/movieRoutes.js
+++ b/src/routes/movieRoutes.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import Movie from '../models/movieModel.js';
+
+const router = express.Router();
+
+// Get all movies
+router.get('/', async (req, res) => {
+  const movies = await Movie.find().sort({ createdAt: -1 });
+  res.json(movies);
+});
+
+// Create a movie entry
+router.post('/', async (req, res) => {
+  try {
+    const movie = await Movie.create(req.body);
+    res.status(201).json(movie);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/src/routes/newsRoutes.js
+++ b/src/routes/newsRoutes.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import News from '../models/newsModel.js';
+
+const router = express.Router();
+
+// Get all news
+router.get('/', async (req, res) => {
+  const news = await News.find().sort({ createdAt: -1 });
+  res.json(news);
+});
+
+// Create news entry
+router.post('/', async (req, res) => {
+  try {
+    const created = await News.create(req.body);
+    res.status(201).json(created);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/src/routes/orders.js
+++ b/src/routes/orders.js
@@ -3,6 +3,7 @@ const router = express.Router();
 import Order from '../models/Order.js';
 import Restaurant from '../models/restaurant.js';
 import Driver from '../models/Driver.js';
+import constants from '../utils/constant.cjs';
 
 // Place order
 router.post('/', async (req, res) => {
@@ -12,8 +13,9 @@ router.post('/', async (req, res) => {
 
   let total = 0;
   items.forEach(it => { total += it.price * (it.qty || 1); });
-  let commission = total * 0.10;
-  let gst = commission * 0.18;
+  const { commissionRate, gstRate } = constants;
+  let commission = total * commissionRate;
+  let gst = commission * gstRate;
   let deliveryFee = 17 + (location.distanceKm || 0) * 2; // or calculate based on distance
   // Optionally add surge fee logic here
 

--- a/src/utils/constant.cjs
+++ b/src/utils/constant.cjs
@@ -1,7 +1,9 @@
 
-module.exports={
-    roles:{
-        admin:'Admin',
-        user:'User'
-    }
-}
+module.exports = {
+  roles: {
+    admin: 'Admin',
+    user: 'User'
+  },
+  commissionRate: 0.1, // 10% platform commission
+  gstRate: 0.18 // 18% government tax
+};


### PR DESCRIPTION
## Summary
- add constants for platform commission and GST
- apply commission constants in order route
- create models and routes for movies, activities and news
- expose new routes in the main server
- document backend purpose

## Testing
- `npm install`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688490e192e4832b82611860e4a43145