### PR TITLE
Add auth and profile endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const io = new Server(server, {
 });
 import connectDB from './src/configs/mongoose.js';
 import auth from './src/middleware/auth.cjs';
-import userRouter from './src/routes/userRouter.js';
+import userRouter from './src/routes/userRoutes.js';
 import menuRouter from './src/routes/menuRouter.js';
 import orderRouter from './src/routes/orderRouter.js';
 import cartRouter from './src/routes/cartRouter.js';

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ const MONGO_URI =
 connectDB(MONGO_URI);
 
 // Import all routers
-import userRouter from './src/routes/userRoutes.cjs';
+import userRouter from './src/routes/userRoutes.js';
 import driverRouter from './src/routes/driverRoutes.js';
 import restaurantRouter from './src/routes/restaurantRoutes.cjs';
 import martRouter from './src/routes/martRoutes.cjs';

--- a/src/controllers/driverController.js
+++ b/src/controllers/driverController.js
@@ -60,6 +60,28 @@ export const getDriverProfile = async (req, res) => {
   }
 };
 
+// Update driver profile
+export const updateDriverProfile = async (req, res) => {
+  const driver = await Driver.findById(req.driver._id);
+  if (!driver) return res.status(404).json({ message: 'Driver not found' });
+
+  driver.name = req.body.name || driver.name;
+  driver.phone = req.body.phone || driver.phone;
+  driver.vehicleNumber = req.body.vehicleNumber || driver.vehicleNumber;
+
+  if (req.body.password) {
+    driver.password = req.body.password;
+  }
+
+  const updated = await driver.save();
+  res.json({
+    _id: updated._id,
+    name: updated.name,
+    phone: updated.phone,
+    vehicleNumber: updated.vehicleNumber,
+  });
+};
+
 // Update availability
 export const toggleDriverAvailability = async (req, res) => {
   const driver = await Driver.findById(req.driver._id);

--- a/src/models/driverModel.js
+++ b/src/models/driverModel.js
@@ -1,5 +1,6 @@
 // src/models/driverModel.js
 import mongoose from 'mongoose';
+import bcrypt from 'bcryptjs';
 
 const driverSchema = new mongoose.Schema(
   {
@@ -69,6 +70,19 @@ driverSchema.virtual('averageRating').get(function () {
 
 driverSchema.set('toObject', { virtuals: true });
 driverSchema.set('toJSON', { virtuals: true });
+
+// Hash password before saving
+driverSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  const salt = await bcrypt.genSalt(10);
+  this.password = await bcrypt.hash(this.password, salt);
+  next();
+});
+
+// Compare entered password with hashed
+driverSchema.methods.matchPassword = async function (entered) {
+  return bcrypt.compare(entered, this.password);
+};
 
 const Driver = mongoose.model('Driver', driverSchema);
 export default Driver;

--- a/src/routes/driverRoutes.js
+++ b/src/routes/driverRoutes.js
@@ -3,6 +3,7 @@ import {
   loginDriver,
   registerDriver,
   getDriverProfile,
+  updateDriverProfile,
   toggleDriverAvailability,
   getAllDrivers,
   approveDriver,
@@ -15,6 +16,7 @@ const router = express.Router();
 router.post('/register', registerDriver);
 router.post('/login', loginDriver);
 router.get('/profile', protectDriver, getDriverProfile);
+router.put('/profile', protectDriver, updateDriverProfile);
 router.patch('/availability', protectDriver, toggleDriverAvailability);
 
 // Admin routes

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import {
+  registerUser,
+  authUser,
+  logoutUser,
+  getUserProfile,
+  updateUserProfile,
+  verifyUser,
+  sendOtp,
+} from '../controllers/userController.js';
+import { protectUser } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.post('/register', registerUser);
+router.post('/login', authUser);
+router.post('/logout', protectUser, logoutUser);
+router.get('/profile', protectUser, getUserProfile);
+router.put('/profile', protectUser, updateUserProfile);
+router.post('/verify', verifyUser);
+router.post('/send-otp', sendOtp);
+
+export default router;


### PR DESCRIPTION
## Summary
- wire up user router using ES modules
- hash driver passwords and allow updates via `/api/drivers/profile`
- support login/signup/profile routes for users

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688498fd5d08832b8aa1146e6f344a97