### PR TITLE
Add application settings API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ Drivers registering for taxi service must provide additional vehicle details.
 During registration they upload a profile photo and driving license number along
 with the vehicle brand, model and plate number. This helps riders identify the
 incoming cab and facilitates phone number exchange between passenger and driver.
+
+## Application Settings
+The `/api/settings` endpoint allows admins to manage global configuration for the app.
+`GET /api/settings` fetches all settings while `POST /api/settings` creates or updates a value. Authentication as an admin is required to modify settings.

--- a/server.js
+++ b/server.js
@@ -47,6 +47,7 @@ import movieRouter from './src/routes/movieRoutes.js';
 import activityRouter from './src/routes/activityRoutes.js';
 import newsRouter from './src/routes/newsRoutes.js';
 import depositRouter from './src/routes/depositRoutes.js';
+import settingRouter from './src/routes/settingRoutes.js';
 
 // Mount API routes
 app.use('/api/users', userRouter);
@@ -67,6 +68,7 @@ app.use('/api/movies', movieRouter);
 app.use('/api/activities', activityRouter);
 app.use('/api/news', newsRouter);
 app.use('/api/deposits', depositRouter);
+app.use('/api/settings', settingRouter);
 
 // Root health check route
 app.get('/', (req, res) => {

--- a/src/controllers/settingController.js
+++ b/src/controllers/settingController.js
@@ -1,0 +1,29 @@
+import Setting from '../models/settingModel.js';
+
+export const getSettings = async (req, res) => {
+  try {
+    const settings = await Setting.find({});
+    res.json(settings);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch settings' });
+  }
+};
+
+export const updateSetting = async (req, res) => {
+  try {
+    const { key, value, description } = req.body;
+    if (!key) return res.status(400).json({ error: 'Key is required' });
+
+    let setting = await Setting.findOne({ key });
+    if (setting) {
+      setting.value = value;
+      if (description !== undefined) setting.description = description;
+    } else {
+      setting = new Setting({ key, value, description });
+    }
+    await setting.save();
+    res.json(setting);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update setting' });
+  }
+};

--- a/src/models/settingModel.js
+++ b/src/models/settingModel.js
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose';
+
+const settingSchema = new mongoose.Schema(
+  {
+    key: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    value: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true,
+    },
+    description: String,
+  },
+  { timestamps: true }
+);
+
+const Setting = mongoose.model('Setting', settingSchema);
+export default Setting;

--- a/src/routes/settingRoutes.js
+++ b/src/routes/settingRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getSettings, updateSetting } from '../controllers/settingController.js';
+import { protectAdmin } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.get('/', getSettings);
+router.post('/', protectAdmin, updateSetting);
+
+export default router;


### PR DESCRIPTION
## Summary
- introduce a `Setting` model and controller for global app configuration
- expose `/api/settings` routes to get or update settings
- mount the new routes in the main server
- document the feature in the README

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68849fcf9fdc832b879588a9adf3e378