### PR TITLE
Add live tracking for bike deliveries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ Drivers and customers can share their real-time location while an order or ride 
 
 - **PUT `/api/users/location`** - update the logged in customer's coordinates.
 - **PUT `/api/drivers/location`** - update the current driver's coordinates.
+- **PUT `/api/bike/location`** - update the location of a bike rider.
 
-WebSocket events `driver-location` and the new `user-location` broadcast updates so both sides can track progress in the app.
+WebSocket events `driver-location`, `bike-location` and the new `user-location` broadcast updates so both sides can track progress in the app.

--- a/socket.js
+++ b/socket.js
@@ -68,6 +68,13 @@ const initSocketServer = (httpServer) => {
       });
     });
 
+    socket.on('bike-location', (location) => {
+      io.of('/user').emit('update-bike-location', {
+        driverId: socket.user.id,
+        location,
+      });
+    });
+
     socket.on('bid-on-request', (bidDetails) => {
       io.of('/user').emit('driver-bid', {
         driverId: socket.user.id,

--- a/src/controllers/bikeController.js
+++ b/src/controllers/bikeController.js
@@ -81,3 +81,20 @@ export const createPorterBikeDelivery = asyncHandler(async (req, res) => {
 
   res.status(201).json({ success: true, order });
 });
+
+// Update Bike Driver Location
+export const updateBikeLocation = asyncHandler(async (req, res) => {
+  const driver = await Driver.findOne({ _id: req.driver._id, vehicleType: 'bike' });
+  if (!driver) {
+    return res.status(404).json({ message: 'Bike driver not found' });
+  }
+
+  driver.location = {
+    lat: req.body.lat,
+    lng: req.body.lng,
+    updatedAt: new Date(),
+  };
+
+  await driver.save();
+  res.json({ message: 'Bike location updated' });
+});

--- a/src/routes/bikeRoutes.js
+++ b/src/routes/bikeRoutes.js
@@ -6,6 +6,7 @@ import {
   createFoodBikeDelivery,
   createMartBikeDelivery,
   createPorterBikeDelivery,
+  updateBikeLocation,
 } from '../controllers/bikeController.js';
 
 import { protectUser, protectDriver } from '../middleware/authMiddleware.js';
@@ -23,5 +24,8 @@ router.post('/bike-delivery/mart', protectUser, createMartBikeDelivery);
 
 // Porter Delivery
 router.post('/bike-delivery/porter', protectUser, createPorterBikeDelivery);
+
+// Update live location for bike drivers
+router.put('/location', protectDriver, updateBikeLocation);
 
 export default router;

--- a/src/socket/socket.js
+++ b/src/socket/socket.js
@@ -62,6 +62,13 @@ const initSocketServer = (httpServer) => {
       });
     });
 
+    socket.on("bike-location", (location) => {
+      userNamespace.emit("update-bike-location", {
+        driverId: socket.user.id,
+        location,
+      });
+    });
+
     socket.on("disconnect", () => {
       console.log("Driver disconnected:", socket.user.id);
     });


### PR DESCRIPTION
## Summary
- support live location updates from bike riders
- expose PUT `/api/bike/location` endpoint
- broadcast `bike-location` socket events
- document bike live tracking in README

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6884a287568c832bb29ad220ef121e6a