### PR TITLE
Add history and support features

### DIFF
--- a/server.js
+++ b/server.js
@@ -68,6 +68,8 @@ import paymentsRouter from './src/routes/payments.js';
 import ordersRouter from './src/routes/orders.js';
 import authRouter from './src/routes/authRoutes.js';
 import adminPortalRouter from './src/routes/admin.js';
+import historyRouter from './src/routes/historyRoutes.js';
+import supportRouter from './src/routes/supportRoutes.js';
 
 // Mount API routes
 app.use('/api/users', userRouter);
@@ -98,6 +100,8 @@ app.use('/api/payments-alt', paymentsRouter);
 app.use('/api/orders-alt', ordersRouter);
 app.use('/api/auth', authRouter);
 app.use('/api/admin-portal', adminPortalRouter);
+app.use('/api/history', historyRouter);
+app.use('/api/support', supportRouter);
 
 // Root health check route
 app.get('/', (req, res) => {

--- a/src/controllers/historyController.js
+++ b/src/controllers/historyController.js
@@ -1,0 +1,22 @@
+import asyncHandler from 'express-async-handler';
+import Order from '../models/orderModel.js';
+import Payment from '../models/paymentModel.js';
+import LoginHistory from '../models/loginHistoryModel.js';
+
+// Get logged in user's order history
+export const getOrderHistory = asyncHandler(async (req, res) => {
+  const orders = await Order.find({ userId: req.user._id }).sort({ createdAt: -1 });
+  res.json(orders);
+});
+
+// Get logged in user's payment history
+export const getPaymentHistory = asyncHandler(async (req, res) => {
+  const payments = await Payment.find({ user: req.user._id }).sort({ createdAt: -1 });
+  res.json(payments);
+});
+
+// Get logged in user's login history
+export const getLoginHistory = asyncHandler(async (req, res) => {
+  const history = await LoginHistory.find({ user: req.user._id }).sort({ loggedInAt: -1 });
+  res.json(history);
+});

--- a/src/controllers/supportController.js
+++ b/src/controllers/supportController.js
@@ -1,0 +1,19 @@
+import asyncHandler from 'express-async-handler';
+import SupportTicket from '../models/supportTicketModel.js';
+
+// Submit a new support ticket
+export const createTicket = asyncHandler(async (req, res) => {
+  const { subject, message } = req.body;
+  const ticket = await SupportTicket.create({
+    user: req.user._id,
+    subject,
+    message,
+  });
+  res.status(201).json(ticket);
+});
+
+// Get all tickets for logged in user
+export const getMyTickets = asyncHandler(async (req, res) => {
+  const tickets = await SupportTicket.find({ user: req.user._id }).sort({ createdAt: -1 });
+  res.json(tickets);
+});

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -51,6 +51,13 @@ export const authUser = asyncHandler(async (req, res) => {
 
   if (user && (await bcrypt.compare(password, user.password))) {
     generateToken(res, user._id);
+    // Record login history
+    const { default: LoginHistory } = await import('../models/loginHistoryModel.js');
+    await LoginHistory.create({
+      user: user._id,
+      userAgent: req.get('user-agent'),
+      ipAddress: req.ip,
+    });
     res.json({
       _id: user._id,
       name: user.name,

--- a/src/models/loginHistoryModel.js
+++ b/src/models/loginHistoryModel.js
@@ -1,0 +1,18 @@
+import mongoose from 'mongoose';
+
+const loginHistorySchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  loggedInAt: {
+    type: Date,
+    default: Date.now,
+  },
+  userAgent: String,
+  ipAddress: String,
+});
+
+const LoginHistory = mongoose.model('LoginHistory', loginHistorySchema);
+export default LoginHistory;

--- a/src/models/supportTicketModel.js
+++ b/src/models/supportTicketModel.js
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose';
+
+const supportTicketSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    subject: { type: String, required: true },
+    message: { type: String, required: true },
+    status: {
+      type: String,
+      enum: ['open', 'closed'],
+      default: 'open',
+    },
+  },
+  { timestamps: true }
+);
+
+const SupportTicket = mongoose.model('SupportTicket', supportTicketSchema);
+export default SupportTicket;

--- a/src/routes/historyRoutes.js
+++ b/src/routes/historyRoutes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import { getOrderHistory, getPaymentHistory, getLoginHistory } from '../controllers/historyController.js';
+import { protectUser } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.use(protectUser);
+
+router.get('/orders', getOrderHistory);
+router.get('/payments', getPaymentHistory);
+router.get('/logins', getLoginHistory);
+
+export default router;

--- a/src/routes/supportRoutes.js
+++ b/src/routes/supportRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import { createTicket, getMyTickets } from '../controllers/supportController.js';
+import { protectUser } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.use(protectUser);
+
+router.post('/', createTicket);
+router.get('/my', getMyTickets);
+
+export default router;


### PR DESCRIPTION
## Summary
- log login history on user login
- track and expose order, payment and login history
- add customer support ticket endpoints
- wire history and support routes

## Testing
- `npm install`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6886214021f8832bba922377603d3f98