### PR TITLE
Fix duplicate Driver model import

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -17,7 +17,7 @@ router.post('/verify-restaurant/:id', async (req, res) => {
   res.json(r);
 });
 router.post('/verify-driver/:id', async (req, res) => {
-  const Driver = (await import('../models/Driver.js')).default;
+  const Driver = (await import('../models/driverModel.js')).default;
   const d = await Driver.findByIdAndUpdate(req.params.id, { verified: true }, { new: true });
   res.json(d);
 });

--- a/src/routes/orders.js
+++ b/src/routes/orders.js
@@ -2,7 +2,6 @@ import express from 'express';
 const router = express.Router();
 import Order from '../models/Order.js';
 import Restaurant from '../models/restaurant.js';
-import Driver from '../models/Driver.js';
 import constants from '../utils/constant.cjs';
 
 // Place order


### PR DESCRIPTION
## Summary
- avoid loading old Driver model in order routes
- use driverModel in admin routes

## Testing
- `npx --yes jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68872b0e3820832b8ba53894ddb6987d