### PR TITLE
Add admin dashboard login and payouts

### DIFF
--- a/.env
+++ b/.env
@@ -22,3 +22,7 @@ EMAIL_FROM=Grab <noreply@grab.com>
 # Razorpay
 RAZORPAY_KEY_ID=your_razorpay_key
 RAZORPAY_KEY_SECRET=your_razorpay_secret
+
+# Admin login
+ADMIN_EMAIL=rakshitbargotra@gmail.com
+ADMIN_PASSWORD=Rakshit@9858

--- a/README.md
+++ b/README.md
@@ -68,3 +68,14 @@ POST /api/auth/register
 
 Set `type` to `user`, `driver`, `rider` or `restaurant` and include the relevant fields. The response returns a JWT token and the created record.
 
+## Admin Dashboard
+
+Admins can authenticate using the `/api/admin/login` endpoint. By default the credentials are taken from the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables. Example values are:
+
+```
+ADMIN_EMAIL=rakshitbargotra@gmail.com
+ADMIN_PASSWORD=Rakshit@9858
+```
+
+After logging in, include the returned token as a Bearer token for all other admin routes. The dashboard statistics are available at `/api/admin/dashboard` and payouts can be managed via `/api/admin/payouts` and `/api/admin/payouts/run`.
+

--- a/src/models/orderModel.js
+++ b/src/models/orderModel.js
@@ -51,10 +51,15 @@ const orderSchema = new Schema({
     enum: ['In Progress', 'Prepared', 'Delivered'], 
     default: 'In Progress' 
   },
-  paymentStatus: { 
-    type: String, 
-    enum: ['Pending', 'Paid'], 
-    default: 'Pending' 
+  paymentStatus: {
+    type: String,
+    enum: ['Pending', 'Paid'],
+    default: 'Pending'
+  },
+  // Track whether the restaurant payout has been processed
+  isPayoutDone: {
+    type: Boolean,
+    default: false,
   },
   orderDate: { type: Date, default: Date.now },
   // User details stored at time of order (for email purposes)

--- a/src/routes/adminRoutes.js
+++ b/src/routes/adminRoutes.js
@@ -7,11 +7,17 @@ import {
   getAllRatings,
   sendAdminNotification,
   updateContent,
+  adminLogin,
+  runAutomaticPayouts,
+  getAllPayouts,
 } from '../controllers/adminController.js';
 
 import { protectAdmin } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
+
+// Admin login
+router.post('/login', adminLogin);
 
 // Admin Dashboard stats
 router.get('/dashboard', protectAdmin, getDashboardStats);
@@ -28,5 +34,11 @@ router.post('/notify', protectAdmin, sendAdminNotification);
 
 // Content Editor (e.g. banners, announcements)
 router.put('/content/:section', protectAdmin, updateContent);
+
+// View all payouts
+router.get('/payouts', protectAdmin, getAllPayouts);
+
+// Trigger payout processing
+router.post('/payouts/run', protectAdmin, runAutomaticPayouts);
 
 export default router;


### PR DESCRIPTION
## Summary
- document new admin dashboard endpoint usage
- enable login and payout calculation in admin controller
- expose new admin routes for login and payouts
- track restaurant payout status in order model
- add default admin credentials in `.env`

## Testing
- `npx jest` *(fails: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68875b1fb558832bb6b35d4a8fc5544d