### PR TITLE
Improve frontend styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,16 @@ ADMIN_PASSWORD=Rakshit@9858
 
 After logging in, include the returned token as a Bearer token for all other admin routes. The dashboard statistics are available at `/api/admin/dashboard` and payouts can be managed via `/api/admin/payouts` and `/api/admin/payouts/run`.
 
+
+## Frontend Demo
+
+The backend serves a small static frontend under the `/app` path. The landing page `/app/` lists each module with Grab-inspired styling. Available sections include:
+
+- `/app/userapp/` – user registration
+- `/app/driverapp/` – driver registration
+- `/app/riderapp/` – rider registration
+- `/app/restaurantapp/` – restaurant registration
+- `/app/martapp/` – mart placeholder
+- `/app/medicineapp/` – medicine store placeholder
+
+All pages share `frontend/style.css`, which uses Grab's green color palette. Forms submit via JavaScript `fetch` requests to the backend API so you can test registrations directly.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,23 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,12 @@
+# Frontend
+
+This folder contains simple static pages for different roles in the Grab SuperApp demo. Each sub directory has its own `index.html` page that interacts with the backend API using vanilla JavaScript.
+
+- `userapp` – basic user registration form
+- `driverapp` – driver registration form
+- `riderapp` – rider registration form
+- `restaurantapp` – restaurant registration form
+- `martapp` – placeholder for mart stores
+- `medicineapp` – placeholder for medicine shops
+
+All pages share a common `style.css` for a minimalist layout. The backend serves these files from the `/app` path.

--- a/frontend/driverapp/index.html
+++ b/frontend/driverapp/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Driver App</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <div class="header">
+    Grab Demo -
+    <nav>
+      <a href="/app/">Home</a>
+      <a href="/app/userapp/">User</a>
+      <a href="/app/driverapp/">Driver</a>
+      <a href="/app/riderapp/">Rider</a>
+      <a href="/app/restaurantapp/">Restaurant</a>
+      <a href="/app/martapp/">Mart</a>
+      <a href="/app/medicineapp/">Medicine</a>
+    </nav>
+  </div>
+  <div class="container">
+    <h1>Driver Registration</h1>
+    <form id="register">
+      <input type="text" id="name" placeholder="Name" required>
+      <input type="text" id="phone" placeholder="Phone" required>
+      <input type="text" id="vehicleType" placeholder="Vehicle Type" required>
+      <input type="text" id="vehicleNumber" placeholder="Vehicle Number" required>
+      <input type="text" id="licenseNumber" placeholder="License Number" required>
+      <input type="password" id="password" placeholder="Password" required>
+      <button type="submit">Register</button>
+    </form>
+    <div id="message"></div>
+  </div>
+<script>
+document.getElementById('register').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    type: 'driver',
+    name: document.getElementById('name').value,
+    phone: document.getElementById('phone').value,
+    password: document.getElementById('password').value,
+    vehicleType: document.getElementById('vehicleType').value,
+    vehicleNumber: document.getElementById('vehicleNumber').value,
+    licenseNumber: document.getElementById('licenseNumber').value
+  };
+  const res = await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  document.getElementById('message').textContent = JSON.stringify(data, null, 2);
+});
+</script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Grab Demo Home</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="header">
+    Grab Demo -
+    <nav>
+      <a href="/app/">Home</a>
+      <a href="/app/userapp/">User</a>
+      <a href="/app/driverapp/">Driver</a>
+      <a href="/app/riderapp/">Rider</a>
+      <a href="/app/restaurantapp/">Restaurant</a>
+      <a href="/app/martapp/">Mart</a>
+      <a href="/app/medicineapp/">Medicine</a>
+    </nav>
+  </div>
+  <div class="container">
+    <h1>Grab SuperApp Frontend Demo</h1>
+    <p>Select a module to try the registration forms:</p>
+    <ul>
+      <li><a href="/app/userapp/">User App</a></li>
+      <li><a href="/app/driverapp/">Driver App</a></li>
+      <li><a href="/app/riderapp/">Rider App</a></li>
+      <li><a href="/app/restaurantapp/">Restaurant App</a></li>
+      <li><a href="/app/martapp/">Mart App</a></li>
+      <li><a href="/app/medicineapp/">Medicine App</a></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/frontend/martapp/index.html
+++ b/frontend/martapp/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Mart App</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <div class="header">
+    Grab Demo -
+    <nav>
+      <a href="/app/">Home</a>
+      <a href="/app/userapp/">User</a>
+      <a href="/app/driverapp/">Driver</a>
+      <a href="/app/riderapp/">Rider</a>
+      <a href="/app/restaurantapp/">Restaurant</a>
+      <a href="/app/martapp/">Mart</a>
+      <a href="/app/medicineapp/">Medicine</a>
+    </nav>
+  </div>
+  <div class="container">
+    <h1>Mart Application</h1>
+    <p>This is a placeholder page for mart store management.</p>
+  </div>
+</body>
+</html>

--- a/frontend/medicineapp/index.html
+++ b/frontend/medicineapp/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Medicine App</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <div class="header">
+    Grab Demo -
+    <nav>
+      <a href="/app/">Home</a>
+      <a href="/app/userapp/">User</a>
+      <a href="/app/driverapp/">Driver</a>
+      <a href="/app/riderapp/">Rider</a>
+      <a href="/app/restaurantapp/">Restaurant</a>
+      <a href="/app/martapp/">Mart</a>
+      <a href="/app/medicineapp/">Medicine</a>
+    </nav>
+  </div>
+  <div class="container">
+    <h1>Medicine Application</h1>
+    <p>This is a placeholder page for pharmacy management.</p>
+  </div>
+</body>
+</html>

--- a/frontend/restaurantapp/index.html
+++ b/frontend/restaurantapp/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Restaurant App</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <div class="header">
+    Grab Demo -
+    <nav>
+      <a href="/app/">Home</a>
+      <a href="/app/userapp/">User</a>
+      <a href="/app/driverapp/">Driver</a>
+      <a href="/app/riderapp/">Rider</a>
+      <a href="/app/restaurantapp/">Restaurant</a>
+      <a href="/app/martapp/">Mart</a>
+      <a href="/app/medicineapp/">Medicine</a>
+    </nav>
+  </div>
+  <div class="container">
+    <h1>Restaurant Registration</h1>
+    <form id="register">
+      <input type="text" id="name" placeholder="Name" required>
+      <input type="text" id="phone" placeholder="Phone" required>
+      <input type="text" id="location" placeholder="Location" required>
+      <input type="password" id="password" placeholder="Password" required>
+      <button type="submit">Register</button>
+    </form>
+    <div id="message"></div>
+  </div>
+<script>
+document.getElementById('register').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    type: 'restaurant',
+    name: document.getElementById('name').value,
+    phone: document.getElementById('phone').value,
+    password: document.getElementById('password').value,
+    location: document.getElementById('location').value
+  };
+  const res = await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  document.getElementById('message').textContent = JSON.stringify(data, null, 2);
+});
+</script>
+</body>
+</html>

--- a/frontend/riderapp/index.html
+++ b/frontend/riderapp/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Rider App</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <div class="header">
+    Grab Demo -
+    <nav>
+      <a href="/app/">Home</a>
+      <a href="/app/userapp/">User</a>
+      <a href="/app/driverapp/">Driver</a>
+      <a href="/app/riderapp/">Rider</a>
+      <a href="/app/restaurantapp/">Restaurant</a>
+      <a href="/app/martapp/">Mart</a>
+      <a href="/app/medicineapp/">Medicine</a>
+    </nav>
+  </div>
+  <div class="container">
+    <h1>Rider Registration</h1>
+    <form id="register">
+      <input type="text" id="name" placeholder="Name" required>
+      <input type="text" id="phone" placeholder="Phone" required>
+      <input type="text" id="vehicleNumber" placeholder="Bike Number" required>
+      <input type="text" id="licenseNumber" placeholder="License Number" required>
+      <input type="password" id="password" placeholder="Password" required>
+      <button type="submit">Register</button>
+    </form>
+    <div id="message"></div>
+  </div>
+<script>
+document.getElementById('register').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    type: 'rider',
+    name: document.getElementById('name').value,
+    phone: document.getElementById('phone').value,
+    password: document.getElementById('password').value,
+    vehicleNumber: document.getElementById('vehicleNumber').value,
+    licenseNumber: document.getElementById('licenseNumber').value
+  };
+  const res = await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  document.getElementById('message').textContent = JSON.stringify(data, null, 2);
+});
+</script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,69 @@
+body {
+  font-family: Helvetica, Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f4f4f4;
+}
+
+.header {
+  background: #00b14f;
+  color: #fff;
+  padding: 16px;
+  text-align: center;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+  margin: 0 8px;
+}
+
+.container {
+  max-width: 640px;
+  margin: 40px auto;
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+  text-align: center;
+  color: #00b14f;
+  margin-top: 0;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+input, button {
+  padding: 12px;
+  font-size: 1rem;
+}
+
+input {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  background: #00b14f;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+button:hover {
+  background: #008f3d;
+}
+
+#message {
+  margin-top: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/frontend/userapp/index.html
+++ b/frontend/userapp/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>User App</title>
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <div class="header">
+    Grab Demo -
+    <nav>
+      <a href="/app/">Home</a>
+      <a href="/app/userapp/">User</a>
+      <a href="/app/driverapp/">Driver</a>
+      <a href="/app/riderapp/">Rider</a>
+      <a href="/app/restaurantapp/">Restaurant</a>
+      <a href="/app/martapp/">Mart</a>
+      <a href="/app/medicineapp/">Medicine</a>
+    </nav>
+  </div>
+  <div class="container">
+    <h1>User Registration</h1>
+    <form id="register">
+      <input type="text" id="name" placeholder="Name" required>
+      <input type="text" id="phone" placeholder="Phone" required>
+      <input type="password" id="password" placeholder="Password" required>
+      <button type="submit">Register</button>
+    </form>
+    <div id="message"></div>
+  </div>
+<script>
+document.getElementById('register').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    type: 'user',
+    name: document.getElementById('name').value,
+    phone: document.getElementById('phone').value,
+    password: document.getElementById('password').value
+  };
+  const res = await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  document.getElementById('message').textContent = JSON.stringify(data, null, 2);
+});
+</script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -33,6 +33,8 @@ if (process.env.NODE_ENV !== 'test') {
 }
 app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 1000 }));
 app.use('/uploads', express.static('uploads'));
+// Serve static frontend
+app.use('/app', express.static('frontend'));
 
 // In-memory store for simple Postman integration tests
 const integrationTokens = new Map();


### PR DESCRIPTION
## Summary
- give frontend pages Grab-themed styling
- add navigation header to each page
- create /app index page listing modules
- update README documentation

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68878c601f44832b95cef9c498997bf4