### PR TITLE
Add refund request system

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ ADMIN_PASSWORD=Rakshit@9858
 
 After logging in, include the returned token as a Bearer token for all other admin routes. The dashboard statistics are available at `/api/admin/dashboard` and payouts can be managed via `/api/admin/payouts` and `/api/admin/payouts/run`.
 
+## Refund Requests
+
+Users can request a refund if an order is cancelled or an issue occurs. Submit a POST request to `/api/refunds` with the order ID and amount. Check request status at `/api/refunds/my`. Admins can process pending refunds via `/api/refunds/run` or wait for the hourly refund scheduler.
+
 
 ## Frontend Demo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "mongoose": "^8.15.0",
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",
+        "node-cron": "^3.0.3",
         "node-fetch": "^3.3.2",
         "nodemailer": "^7.0.3",
         "razorpay": "^2.9.6",
@@ -4392,6 +4393,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mongoose": "^8.15.0",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
+    "node-cron": "^3.0.3",
     "node-fetch": "^3.3.2",
     "nodemailer": "^7.0.3",
     "razorpay": "^2.9.6",

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ import { initSocketServer } from './src/socket/socket.js';
 import connectDB from './src/configs/mongoose.js';
 import errorHandler from './src/middleware/errorMiddleware.js';
 import crypto from 'crypto';
+import { startRefundScheduler } from './src/jobs/refundScheduler.js';
 
 // Load environment variables
 dotenv.config();
@@ -109,6 +110,7 @@ import authRouter from './src/routes/authRoutes.js';
 import adminPortalRouter from './src/routes/admin.js';
 import historyRouter from './src/routes/historyRoutes.js';
 import supportRouter from './src/routes/supportRoutes.js';
+import refundRouter from './src/routes/refundRoutes.js';
 
 // Mount API routes
 app.use('/api/users', userRouter);
@@ -143,6 +145,7 @@ app.use('/api/auth', authRouter);
 app.use('/api/admin-portal', adminPortalRouter);
 app.use('/api/history', historyRouter);
 app.use('/api/support', supportRouter);
+app.use('/api/refunds', refundRouter);
 
 // Endpoint to list all available API routes
 app.get('/api', (req, res) => {
@@ -158,6 +161,9 @@ app.get('/', (req, res) => {
 
 // Global error handler
 app.use(errorHandler);
+
+// Start scheduled refund processing
+startRefundScheduler();
 
 // Start server
 const PORT = process.env.PORT || 5000;

--- a/src/controllers/refundController.js
+++ b/src/controllers/refundController.js
@@ -1,0 +1,41 @@
+import asyncHandler from 'express-async-handler';
+import RefundRequest from '../models/refundRequestModel.js';
+import Payment from '../models/paymentModel.js';
+
+// User requests a refund
+export const requestRefund = asyncHandler(async (req, res) => {
+  const { orderId, amount, reason } = req.body;
+  if (!orderId || !amount) {
+    return res.status(400).json({ message: 'orderId and amount are required' });
+  }
+  const refund = await RefundRequest.create({
+    user: req.user._id,
+    orderId,
+    amount,
+    reason,
+  });
+  res.status(201).json(refund);
+});
+
+// Get refunds for logged in user
+export const getMyRefunds = asyncHandler(async (req, res) => {
+  const refunds = await RefundRequest.find({ user: req.user._id }).sort({ createdAt: -1 });
+  res.json(refunds);
+});
+
+// Admin processes pending refunds
+export const runRefunds = asyncHandler(async (req, res) => {
+  const pending = await RefundRequest.find({ status: 'pending' });
+  let processed = 0;
+  for (const reqRef of pending) {
+    await Payment.findOneAndUpdate(
+      { orderId: reqRef.orderId },
+      { status: 'refunded', refundedAmount: reqRef.amount, refundReason: reqRef.reason }
+    );
+    reqRef.status = 'processed';
+    reqRef.processedAt = new Date();
+    await reqRef.save();
+    processed++;
+  }
+  res.json({ processed });
+});

--- a/src/jobs/refundScheduler.js
+++ b/src/jobs/refundScheduler.js
@@ -1,0 +1,16 @@
+import cron from 'node-cron';
+import { processPendingRefunds } from '../services/refundService.js';
+
+export function startRefundScheduler() {
+  // Runs at minute 0 of every hour
+  cron.schedule('0 * * * *', async () => {
+    try {
+      const count = await processPendingRefunds();
+      if (count > 0) {
+        console.log(`Processed ${count} refund request(s)`);
+      }
+    } catch (err) {
+      console.error('Error running refund scheduler', err);
+    }
+  });
+}

--- a/src/models/refundRequestModel.js
+++ b/src/models/refundRequestModel.js
@@ -1,0 +1,34 @@
+import mongoose from 'mongoose';
+
+const refundRequestSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    orderId: {
+      type: String,
+      required: true,
+    },
+    amount: {
+      type: Number,
+      required: true,
+    },
+    reason: {
+      type: String,
+      default: '',
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'processed', 'rejected'],
+      default: 'pending',
+    },
+    processedAt: Date,
+    notes: String,
+  },
+  { timestamps: true }
+);
+
+const RefundRequest = mongoose.model('RefundRequest', refundRequestSchema);
+export default RefundRequest;

--- a/src/routes/refundRoutes.js
+++ b/src/routes/refundRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { requestRefund, getMyRefunds, runRefunds } from '../controllers/refundController.js';
+import { protectUser, protectAdmin } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.post('/', protectUser, requestRefund);
+router.get('/my', protectUser, getMyRefunds);
+router.post('/run', protectAdmin, runRefunds);
+
+export default router;

--- a/src/services/refundService.js
+++ b/src/services/refundService.js
@@ -1,0 +1,16 @@
+import RefundRequest from '../models/refundRequestModel.js';
+import Payment from '../models/paymentModel.js';
+
+export async function processPendingRefunds() {
+  const pending = await RefundRequest.find({ status: 'pending' });
+  for (const reqRef of pending) {
+    await Payment.findOneAndUpdate(
+      { orderId: reqRef.orderId },
+      { status: 'refunded', refundedAmount: reqRef.amount, refundReason: reqRef.reason }
+    );
+    reqRef.status = 'processed';
+    reqRef.processedAt = new Date();
+    await reqRef.save();
+  }
+  return pending.length;
+}


### PR DESCRIPTION
## Summary
- implement `RefundRequest` model
- add controller with endpoints for requesting and processing refunds
- include refund processing service
- add hourly scheduler via `node-cron`
- document refund endpoints
- mount new `/api/refunds` routes

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688bb330f7fc832bb75afcd798eb4570