### PR TITLE
Add driver taxi request endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ WebSocket events `driver-location`, `bike-location` and the new `user-location` 
 
 The backend exposes dedicated routes for each module:
 
-- **Driver App:** `/api/drivers` for driver registration, login and profile management.
+- **Driver App:** `/api/drivers` for driver registration, login and profile management. Drivers can fetch open ride requests via `/api/drivers/taxi/requests`, see current assignments at `/api/drivers/taxi/active`, and view earnings analytics at `/api/drivers/analytics`.
 - **Rider App:** `/api/bike` handles bike taxi rides and deliveries.
 - **Restaurant App:** `/api/restaurants` manages menus and order status updates.
 - **Porter App:** `/api/porter` allows customers to book porter deliveries.

--- a/src/routes/driverRoutes.js
+++ b/src/routes/driverRoutes.js
@@ -9,6 +9,9 @@ import {
   getAllDrivers,
   approveDriver,
   deleteDriver,
+  getOpenTaxiRequests,
+  getActiveDriverRides,
+  getDriverAnalytics,
 } from '../controllers/driverController.js';
 import { protectDriver, protectAdmin } from '../middleware/authMiddleware.js';
 
@@ -20,6 +23,11 @@ router.get('/profile', protectDriver, getDriverProfile);
 router.put('/profile', protectDriver, updateDriverProfile);
 router.patch('/availability', protectDriver, toggleDriverAvailability);
 router.put('/location', protectDriver, updateDriverLocation);
+
+// Taxi booking helpers for drivers
+router.get('/taxi/requests', protectDriver, getOpenTaxiRequests);
+router.get('/taxi/active', protectDriver, getActiveDriverRides);
+router.get('/analytics', protectDriver, getDriverAnalytics);
 
 // Admin routes
 router.get('/', protectAdmin, getAllDrivers);


### PR DESCRIPTION
## Summary
- add endpoints for drivers to fetch open taxi bookings and analytics
- expose new helper routes in driver router
- document driver APIs in README

## Testing
- `npm install`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688bba0a390c832ba6d7501db4c92162