### PR TITLE
Add bid management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ After logging in, include the returned token as a Bearer token for all other adm
 
 Users can request a refund if an order is cancelled or an issue occurs. Submit a POST request to `/api/refunds` with the order ID and amount. Check request status at `/api/refunds/my`. Admins can process pending refunds via `/api/refunds/run` or wait for the hourly refund scheduler.
 
+## Ride Bidding
+
+Drivers can place bids on open ride requests and users may accept the bid they prefer.
+
+- **POST `/api/bids/create`** – driver submits a bid for a ride. Requires `rideId` and `amount` in the body.
+- **POST `/api/bids/accept`** – user accepts a bid by ID. The ride is assigned to the bidding driver.
+- **GET `/api/bids/status/:rideId`** – fetch current bids for a ride.
+
+Socket events `driver-bid` and `bid-accepted` keep both parties updated in real time.
+
 
 ## Frontend Demo
 

--- a/server.js
+++ b/server.js
@@ -111,6 +111,7 @@ import adminPortalRouter from './src/routes/admin.js';
 import historyRouter from './src/routes/historyRoutes.js';
 import supportRouter from './src/routes/supportRoutes.js';
 import refundRouter from './src/routes/refundRoutes.js';
+import bidRouter from './src/routes/bidRoutes.js';
 
 // Mount API routes
 app.use('/api/users', userRouter);
@@ -146,6 +147,7 @@ app.use('/api/admin-portal', adminPortalRouter);
 app.use('/api/history', historyRouter);
 app.use('/api/support', supportRouter);
 app.use('/api/refunds', refundRouter);
+app.use('/api/bids', bidRouter);
 
 // Endpoint to list all available API routes
 app.get('/api', (req, res) => {

--- a/src/controllers/bidController.js
+++ b/src/controllers/bidController.js
@@ -1,0 +1,74 @@
+import Bid from '../models/bidModel.js';
+import Ride from '../models/Ride.js';
+import { getIO } from '../socket/socket.js';
+
+// Driver places a bid on a ride
+export const createBid = async (req, res) => {
+  try {
+    const { rideId, amount } = req.body;
+    const ride = await Ride.findById(rideId);
+    if (!ride) return res.status(404).json({ message: 'Ride not found' });
+
+    const bid = await Bid.create({
+      ride: rideId,
+      driver: req.driver._id,
+      user: ride.customerId,
+      amount,
+    });
+
+    ride.bids.push({ driverId: req.driver._id.toString(), amount, status: 'bid' });
+    await ride.save();
+
+    const io = getIO();
+    if (io) {
+      io.of('/user').emit('driver-bid', { rideId, driverId: req.driver._id, amount });
+    }
+
+    res.status(201).json(bid);
+  } catch (err) {
+    res.status(500).json({ message: 'Failed to place bid' });
+  }
+};
+
+// User accepts a bid
+export const acceptBid = async (req, res) => {
+  try {
+    const { bidId } = req.body;
+    const bid = await Bid.findById(bidId).populate('ride');
+    if (!bid) return res.status(404).json({ message: 'Bid not found' });
+    const ride = bid.ride;
+    if (ride.customerId.toString() !== req.userDetails._id.toString()) {
+      return res.status(403).json({ message: 'Not authorized' });
+    }
+
+    bid.status = 'accepted';
+    await bid.save();
+
+    ride.assignedDriver = bid.driver.toString();
+    ride.fare = bid.amount;
+    ride.status = 'assigned';
+    await ride.save();
+
+    await Bid.updateMany({ ride: ride._id, _id: { $ne: bidId } }, { status: 'rejected' });
+
+    const io = getIO();
+    if (io) {
+      io.of('/driver').emit('bid-accepted', { rideId: ride._id, driverId: bid.driver });
+    }
+
+    res.json({ message: 'Bid accepted', rideId: ride._id, driverId: bid.driver });
+  } catch (err) {
+    res.status(500).json({ message: 'Failed to accept bid' });
+  }
+};
+
+// Get bids for a ride
+export const getBidsByRide = async (req, res) => {
+  try {
+    const { rideId } = req.params;
+    const bids = await Bid.find({ ride: rideId }).populate('driver', 'name');
+    res.json(bids);
+  } catch (err) {
+    res.status(500).json({ message: 'Failed to fetch bids' });
+  }
+};

--- a/src/models/bidModel.js
+++ b/src/models/bidModel.js
@@ -1,0 +1,18 @@
+import mongoose from 'mongoose';
+
+const bidSchema = new mongoose.Schema(
+  {
+    ride: { type: mongoose.Schema.Types.ObjectId, ref: 'Ride', required: true },
+    driver: { type: mongoose.Schema.Types.ObjectId, ref: 'Driver', required: true },
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    amount: { type: Number, required: true },
+    status: {
+      type: String,
+      enum: ['pending', 'accepted', 'rejected', 'withdrawn'],
+      default: 'pending',
+    },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Bid', bidSchema);

--- a/src/routes/bidRoutes.js
+++ b/src/routes/bidRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { createBid, acceptBid, getBidsByRide } from '../controllers/bidController.js';
+import { protectDriver, protectUser } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.post('/create', protectDriver, createBid);
+router.post('/accept', protectUser, acceptBid);
+router.get('/status/:rideId', protectUser, getBidsByRide);
+
+export default router;


### PR DESCRIPTION
## Summary
- implement `/api/bids` endpoints
- record bids in new model and emit socket events
- register bid router in the app
- document new bidding workflow in README

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688bbd88b93c832bbeafd67eb45abb2e