### PR TITLE
Add rider and partner API endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -112,6 +112,8 @@ import historyRouter from './src/routes/historyRoutes.js';
 import supportRouter from './src/routes/supportRoutes.js';
 import refundRouter from './src/routes/refundRoutes.js';
 import bidRouter from './src/routes/bidRoutes.js';
+import bikerAppRouter from './src/routes/bikerAppRoutes.js';
+import partnerAppRouter from './src/routes/partnerAppRoutes.js';
 
 // Mount API routes
 app.use('/api/users', userRouter);
@@ -121,6 +123,8 @@ app.use('/api/mart', martRouter);
 app.use('/api/porter', porterRouter);
 app.use('/api/medicine', medicineRouter);
 app.use('/api/bike', bikeRouter);
+app.use('/api/biker', bikerAppRouter);
+app.use('/api/partner', partnerAppRouter);
 app.use('/api/taxi', taxiRouter);
 app.use('/api/admin/taxi', adminTaxiRoutes);
 app.use('/api/wallet', walletRouter);

--- a/src/controllers/bikerAppController.js
+++ b/src/controllers/bikerAppController.js
@@ -1,0 +1,144 @@
+import Driver from '../models/driverModel.js';
+import Order from '../models/Order.js';
+import Wallet from '../models/walletModel.js';
+import Payout from '../models/payoutModel.js';
+import generateToken from '../utils/generateToken.js';
+
+export const registerBiker = async (req, res) => {
+  try {
+    const { email, password, name, phone, vehicleNumber, licenseNumber } = req.body;
+    const exists = await Driver.findOne({ email });
+    if (exists) return res.status(400).json({ message: 'Biker already exists' });
+    const biker = await Driver.create({
+      email,
+      password,
+      name,
+      phone,
+      vehicleNumber,
+      licenseNumber,
+      vehicleType: 'bike',
+    });
+    res.status(201).json({ token: generateToken(biker._id), biker });
+  } catch (err) {
+    res.status(500).json({ message: 'Registration failed' });
+  }
+};
+
+export const loginBiker = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const biker = await Driver.findOne({ email, vehicleType: 'bike' });
+    if (!biker || !(await biker.matchPassword(password))) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    res.json({ token: generateToken(biker._id), biker });
+  } catch (err) {
+    res.status(500).json({ message: 'Login failed' });
+  }
+};
+
+export const getProfile = (req, res) => {
+  res.json(req.driver);
+};
+
+export const updateProfile = async (req, res) => {
+  const driver = req.driver;
+  driver.name = req.body.name || driver.name;
+  driver.phone = req.body.phone || driver.phone;
+  if (req.body.password) driver.password = req.body.password;
+  driver.vehicleNumber = req.body.vehicleNumber || driver.vehicleNumber;
+  driver.licenseNumber = req.body.licenseNumber || driver.licenseNumber;
+  await driver.save();
+  res.json(driver);
+};
+
+export const toggleAvailability = async (req, res) => {
+  const driver = req.driver;
+  driver.isActive = !driver.isActive;
+  await driver.save();
+  res.json({ isActive: driver.isActive });
+};
+
+export const getAssignedOrders = async (req, res) => {
+  const orders = await Order.find({ riderId: req.driver._id, status: { $ne: 'delivered' } });
+  res.json(orders);
+};
+
+export const acceptOrder = async (req, res) => {
+  const { orderId } = req.body;
+  const order = await Order.findById(orderId);
+  if (!order) return res.status(404).json({ message: 'Order not found' });
+  if (order.riderId && order.riderId.toString() !== req.driver._id.toString()) {
+    return res.status(400).json({ message: 'Already assigned' });
+  }
+  order.riderId = req.driver._id;
+  order.status = 'accepted';
+  await order.save();
+  res.json(order);
+};
+
+export const rejectOrder = async (req, res) => {
+  const { orderId } = req.body;
+  const order = await Order.findById(orderId);
+  if (!order) return res.status(404).json({ message: 'Order not found' });
+  order.status = 'rejected';
+  await order.save();
+  res.json(order);
+};
+
+export const getOrder = async (req, res) => {
+  const { orderId } = req.params;
+  const order = await Order.findById(orderId);
+  if (!order) return res.status(404).json({ message: 'Order not found' });
+  if (order.riderId && order.riderId.toString() !== req.driver._id.toString()) {
+    return res.status(403).json({ message: 'Not your order' });
+  }
+  res.json(order);
+};
+
+export const updateOrderStatus = async (req, res) => {
+  const { orderId } = req.params;
+  const { status } = req.body;
+  const order = await Order.findById(orderId);
+  if (!order) return res.status(404).json({ message: 'Order not found' });
+  if (order.riderId?.toString() !== req.driver._id.toString()) {
+    return res.status(403).json({ message: 'Not your order' });
+  }
+  order.status = status;
+  await order.save();
+  res.json(order);
+};
+
+export const completeOrder = async (req, res) => {
+  const { orderId } = req.params;
+  const order = await Order.findById(orderId);
+  if (!order) return res.status(404).json({ message: 'Order not found' });
+  if (order.riderId?.toString() !== req.driver._id.toString()) {
+    return res.status(403).json({ message: 'Not your order' });
+  }
+  order.status = 'delivered';
+  await order.save();
+  res.json(order);
+};
+
+export const getCompletedOrders = async (req, res) => {
+  const orders = await Order.find({ riderId: req.driver._id, status: 'delivered' });
+  res.json(orders);
+};
+
+export const getWallet = async (req, res) => {
+  const wallet = await Wallet.findOne({ user: req.driver._id });
+  res.json(wallet || { balance: 0 });
+};
+
+export const requestPayout = async (req, res) => {
+  const { amount, method } = req.body;
+  const payout = await Payout.create({
+    amount,
+    to: req.driver._id,
+    toRole: 'Driver',
+    method,
+  });
+  res.status(201).json(payout);
+};
+

--- a/src/controllers/partnerAppController.js
+++ b/src/controllers/partnerAppController.js
@@ -1,0 +1,134 @@
+import Partner from '../models/partnerModel.js';
+import Menu from '../models/menuModel.js';
+import MartProduct from '../models/martModel.js';
+import Order from '../models/Order.js';
+import Wallet from '../models/walletModel.js';
+import Payout from '../models/payoutModel.js';
+import generateToken from '../utils/generateToken.js';
+
+export const registerPartner = async (req, res) => {
+  try {
+    const { name, phone, email, password, partnerType } = req.body;
+    const exists = await Partner.findOne({ phone });
+    if (exists) return res.status(400).json({ message: 'Partner already exists' });
+    const partner = await Partner.create({ name, phone, email, password, partnerType });
+    res.status(201).json({ token: generateToken(partner._id), partner });
+  } catch (err) {
+    res.status(500).json({ message: 'Registration failed' });
+  }
+};
+
+export const loginPartner = async (req, res) => {
+  try {
+    const { phone, password } = req.body;
+    const partner = await Partner.findOne({ phone });
+    if (!partner || partner.password !== password) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    res.json({ token: generateToken(partner._id), partner });
+  } catch (err) {
+    res.status(500).json({ message: 'Login failed' });
+  }
+};
+
+export const getProfile = (req, res) => {
+  res.json(req.partner);
+};
+
+export const updateProfile = async (req, res) => {
+  const partner = req.partner;
+  partner.name = req.body.name || partner.name;
+  partner.address = req.body.address || partner.address;
+  await partner.save();
+  res.json(partner);
+};
+
+export const toggleAvailability = async (req, res) => {
+  const partner = req.partner;
+  partner.isActive = !partner.isActive;
+  await partner.save();
+  res.json({ isActive: partner.isActive });
+};
+
+export const getMenu = async (req, res) => {
+  if (req.partner.partnerType === 'restaurant') {
+    const items = await Menu.find();
+    return res.json(items);
+  }
+  const items = await MartProduct.find();
+  res.json(items);
+};
+
+export const addMenuItem = async (req, res) => {
+  let item;
+  if (req.partner.partnerType === 'restaurant') {
+    item = await Menu.create({ ...req.body });
+  } else {
+    item = await MartProduct.create({ ...req.body });
+  }
+  res.status(201).json(item);
+};
+
+export const editMenuItem = async (req, res) => {
+  const { itemId } = req.params;
+  let item;
+  if (req.partner.partnerType === 'restaurant') {
+    item = await Menu.findByIdAndUpdate(itemId, req.body, { new: true });
+  } else {
+    item = await MartProduct.findByIdAndUpdate(itemId, req.body, { new: true });
+  }
+  if (!item) return res.status(404).json({ message: 'Item not found' });
+  res.json(item);
+};
+
+export const deleteMenuItem = async (req, res) => {
+  const { itemId } = req.params;
+  let item;
+  if (req.partner.partnerType === 'restaurant') {
+    item = await Menu.findByIdAndDelete(itemId);
+  } else {
+    item = await MartProduct.findByIdAndDelete(itemId);
+  }
+  if (!item) return res.status(404).json({ message: 'Item not found' });
+  res.json({ message: 'Deleted' });
+};
+
+export const getActiveOrders = async (req, res) => {
+  const orders = await Order.find({ partner: req.partner._id, status: { $ne: 'delivered' } });
+  res.json(orders);
+};
+
+export const updateOrderStatus = async (req, res) => {
+  const { orderId } = req.params;
+  const { status } = req.body;
+  const order = await Order.findById(orderId);
+  if (!order) return res.status(404).json({ message: 'Order not found' });
+  if (order.partner.toString() !== req.partner._id.toString()) {
+    return res.status(403).json({ message: 'Not your order' });
+  }
+  order.status = status;
+  await order.save();
+  res.json(order);
+};
+
+export const getOrderHistory = async (req, res) => {
+  const orders = await Order.find({ partner: req.partner._id, status: 'delivered' });
+  res.json(orders);
+};
+
+export const getWallet = async (req, res) => {
+  const wallet = await Wallet.findOne({ user: req.partner._id });
+  res.json(wallet || { balance: 0 });
+};
+
+export const requestPayout = async (req, res) => {
+  const { amount, method } = req.body;
+  const payout = await Payout.create({
+    amount,
+    to: req.partner._id,
+    toRole: 'Partner',
+    method,
+  });
+  res.status(201).json(payout);
+};
+

--- a/src/middleware/partnerAuth.js
+++ b/src/middleware/partnerAuth.js
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken';
+import Partner from '../models/partnerModel.js';
+
+const JWT_SECRET = process.env.JWT_SECRET || '#479@/^5149*@123';
+
+export const protectPartner = async (req, res, next) => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided' });
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    const partner = await Partner.findById(decoded.id);
+    if (!partner) return res.status(404).json({ message: 'Partner not found' });
+    req.partner = partner;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};
+
+export default protectPartner;

--- a/src/routes/bikerAppRoutes.js
+++ b/src/routes/bikerAppRoutes.js
@@ -1,0 +1,39 @@
+import express from 'express';
+import {
+  registerBiker,
+  loginBiker,
+  getProfile,
+  updateProfile,
+  toggleAvailability,
+  getAssignedOrders,
+  acceptOrder,
+  rejectOrder,
+  getOrder,
+  updateOrderStatus,
+  completeOrder,
+  getCompletedOrders,
+  getWallet,
+  requestPayout,
+} from '../controllers/bikerAppController.js';
+import { protectDriver } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.post('/register', registerBiker);
+router.post('/login', loginBiker);
+router.get('/profile', protectDriver, getProfile);
+router.put('/profile/update', protectDriver, updateProfile);
+router.patch('/availability', protectDriver, toggleAvailability);
+
+router.get('/orders/assigned', protectDriver, getAssignedOrders);
+router.post('/orders/accept', protectDriver, acceptOrder);
+router.post('/orders/reject', protectDriver, rejectOrder);
+router.get('/orders/:orderId', protectDriver, getOrder);
+router.patch('/orders/:orderId/status', protectDriver, updateOrderStatus);
+router.post('/orders/:orderId/complete', protectDriver, completeOrder);
+router.get('/orders/completed', protectDriver, getCompletedOrders);
+
+router.get('/wallet', protectDriver, getWallet);
+router.post('/payout/request', protectDriver, requestPayout);
+
+export default router;

--- a/src/routes/partnerAppRoutes.js
+++ b/src/routes/partnerAppRoutes.js
@@ -1,0 +1,40 @@
+import express from 'express';
+import {
+  registerPartner,
+  loginPartner,
+  getProfile,
+  updateProfile,
+  toggleAvailability,
+  getMenu,
+  addMenuItem,
+  editMenuItem,
+  deleteMenuItem,
+  getActiveOrders,
+  updateOrderStatus,
+  getOrderHistory,
+  getWallet,
+  requestPayout,
+} from '../controllers/partnerAppController.js';
+import { protectPartner } from '../middleware/partnerAuth.js';
+
+const router = express.Router();
+
+router.post('/register', registerPartner);
+router.post('/login', loginPartner);
+router.get('/profile', protectPartner, getProfile);
+router.put('/profile/update', protectPartner, updateProfile);
+router.patch('/availability', protectPartner, toggleAvailability);
+
+router.get('/menu', protectPartner, getMenu);
+router.post('/menu/add', protectPartner, addMenuItem);
+router.put('/menu/edit/:itemId', protectPartner, editMenuItem);
+router.delete('/menu/delete/:itemId', protectPartner, deleteMenuItem);
+
+router.get('/orders/active', protectPartner, getActiveOrders);
+router.patch('/orders/:orderId/status', protectPartner, updateOrderStatus);
+router.get('/orders/history', protectPartner, getOrderHistory);
+
+router.get('/wallet', protectPartner, getWallet);
+router.post('/payout/request', protectPartner, requestPayout);
+
+export default router;


### PR DESCRIPTION
## Summary
- add dedicated biker API routes for registration, order management and payouts
- create partner API for restaurants/marts/medicine shops
- add partner auth middleware
- mount new routers in `server.js`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688bc0434ac0832bbfeaf1eb1b5d4dbc